### PR TITLE
Keybindings: more dynamic 'skip back' implementation

### DIFF
--- a/ts/components/Scrubber.tsx
+++ b/ts/components/Scrubber.tsx
@@ -67,7 +67,7 @@ class Scrubber extends React.Component<ScrubberProps, ScrubberState> {
 			case 37: // left arrow
 			case 74: // j<
 				e.preventDefault();
-				this.props.scrubber.previousTurn();
+				this.props.scrubber.skipBack();
 				break;
 			case 39: // right arrow
 			case 76: // l

--- a/ts/interfaces.d.ts
+++ b/ts/interfaces.d.ts
@@ -86,6 +86,7 @@ export interface StreamScrubber extends EventEmitter {
 	setInhibitor(inhibitor:StreamScrubberInhibitor):void;
 	nextTurn():void;
 	previousTurn():void;
+	skipBack():void;
 	hasEnded():boolean;
 }
 

--- a/ts/state/GameStateScrubber.ts
+++ b/ts/state/GameStateScrubber.ts
@@ -218,6 +218,19 @@ class GameStateScrubber extends Stream.Duplex implements StreamScrubber {
 		this.currentTime = previousTurn;
 		this.update();
 	}
+
+	public skipBack():void {
+		let currentTurn = this.lastState.getEntity(1).getTag(GameTag.TURN);
+		let turnStart = this.history.turnMap.get(currentTurn).getTime();
+		let timeElapsed = this.currentTime - turnStart;
+		if (timeElapsed > 1.5 * this.speed) {
+			this.currentTime = turnStart;
+			this.update();
+		}
+		else {
+			this.previousTurn();
+		}
+	}
 }
 
 export default GameStateScrubber;


### PR DESCRIPTION
`skipBack` skips to the start of the current turn, if more than 1.5 seconds (relative to speed) have elapsed, otherwise to the previous turn.

Left `previousTurn` untouched since it's still a valid operation.