### PR TITLE
Implement DISPLAYED_CREATOR when hovering hand cards

### DIFF
--- a/less/joust.less
+++ b/less/joust.less
@@ -98,6 +98,10 @@
 			.card.revealed {
 				z-index: 1;
 				transform: scale(1.5) translate(0px, -13%);
+				.created-by {
+					visibility: visible;
+					top: -10%;
+				}
 			}
 		}
 	}
@@ -160,6 +164,9 @@
 
 .player.top .hand .card.revealed:hover {
 	transform: scale(1.5) translate(0px, 13%);
+	.created-by {
+		top: 96%;
+	}
 }
 
 .card {
@@ -242,6 +249,22 @@
 		top: 8%;
 		left: 4%;
 		font-size: 1.4em;
+	}
+
+	.created-by {
+		visibility: hidden;
+		position: absolute;
+		top: 96%;
+		left:15%;
+		width:70%;
+		font-size: 0.5em;
+		text-align: center;
+		font-family: "Belwe Bd BT";
+		color: white;
+		text-shadow: -1px -1px 0 #000,
+			1px -1px 0 #000,
+		-1px 1px 0 #000,
+		1px 1px 0 #000;
 	}
 
 	.atk {

--- a/ts/Entity.ts
+++ b/ts/Entity.ts
@@ -97,6 +97,10 @@ class Entity {
 		return this.getTag(GameTag.ZONE_POSITION);
 	}
 
+	public getDisplayedCreator():number {
+		return this.getTag(GameTag.DISPLAYED_CREATOR);
+	}
+
 	public isPoweredUp():boolean {
 		return this.getTag(GameTag.POWERED_UP) > 0;
 	}

--- a/ts/components/GameWidget.tsx
+++ b/ts/components/GameWidget.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {GameWidgetProps, JoustClient, CardDataProps, AssetDirectoryProps, CardOracle} from "../interfaces";
+import {GameWidgetProps, JoustClient, CardDataProps, AssetDirectoryProps, CardOracle, RevealedCardData} from "../interfaces";
 import Scrubber from "./Scrubber";
 import GameState from "../state/GameState";
 import GameWrapper from "./GameWrapper";
@@ -15,7 +15,7 @@ interface GameWidgetState {
 	swapPlayers?:boolean;
 	isFullscreen?:boolean;
 	isFullscreenAvailable?:boolean;
-	cardOracle?:Immutable.Map<number, string>;
+	cardOracle?:Immutable.Map<number, RevealedCardData>;
 	cards?:Immutable.Map<string, CardData>;
 	isRevealingCards?:boolean;
 }
@@ -78,7 +78,7 @@ class GameWidget extends React.Component<GameWidgetProps, GameWidgetState> {
 		this.triggerResize();
 	}
 
-	protected updateCardOracle(cards:Immutable.Map<number, string>) {
+	protected updateCardOracle(cards:Immutable.Map<number, RevealedCardData>) {
 		this.setState({cardOracle: cards});
 	}
 

--- a/ts/components/game/Card.tsx
+++ b/ts/components/game/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {EntityProps, OptionProps, CardDataProps} from "../../interfaces";
+import {EntityProps, OptionProps, CardDataProps, CardOracleProps} from "../../interfaces";
 
 import Attack from './stats/Attack';
 import Health from './stats/Health';
@@ -13,7 +13,7 @@ import {CardType} from "../../enums";
 import {GameTag} from "../../enums";
 import Entity from "../../Entity";
 
-interface CardProps extends EntityProps, OptionProps, CardDataProps, React.Props<any> {
+interface CardProps extends EntityProps, OptionProps, CardDataProps, CardOracleProps, React.Props<any> {
 	style?:any;
 	connectDragSource?(react:React.ReactElement<CardProps>);
 	dragging?:boolean;
@@ -54,6 +54,7 @@ class Card extends React.Component<CardProps, {}> {
 		var defaultCost = null;
 		var defaultHealth = null;
 		var defaultDurability = null;
+		var creatorCardId = null;
 		var cardType = entity.getCardType();
 		if (canBeRevealed) {
 			var data = this.props.cards && this.props.cards.get(entity.getCardId());
@@ -63,6 +64,15 @@ class Card extends React.Component<CardProps, {}> {
 			defaultCost = data.cost;
 			defaultHealth = data.health;
 			defaultDurability = data.durability;
+			let creatorId = entity.getTag(GameTag.DISPLAYED_CREATOR);
+			if (this.props.cardOracle){
+				if (!creatorId) {
+					creatorId = this.props.cardOracle.get(entity.getId()).creator;
+				}
+				if (creatorId) {
+					creatorCardId = this.props.cardOracle.get(creatorId).cardId;
+				}
+			}
 			if (this.props.isHidden) {
 				switch (data.type) {
 					case 'MINION':
@@ -121,6 +131,9 @@ class Card extends React.Component<CardProps, {}> {
 					<p style={textStyle} dangerouslySetInnerHTML={{__html: description}}></p>
 				</div>
 				{stats}
+				<div className="created-by">
+					{creatorCardId && this.props.cards ? 'Created by ' + this.props.cards.get(creatorCardId).name : null}
+				</div>
 			</div>
 		);
 

--- a/ts/components/game/Hand.tsx
+++ b/ts/components/game/Hand.tsx
@@ -47,6 +47,7 @@ class Hand extends EntityList {
 					  isHidden={hidden}
 					  controller={this.props.controller}
 					  textureDirectory={this.props.textureDirectory}
+					  cardOracle={this.props.cardOracle}
 		/>);
 	}
 }

--- a/ts/components/game/Hand.tsx
+++ b/ts/components/game/Hand.tsx
@@ -33,7 +33,7 @@ class Hand extends EntityList {
 
 		var hidden = false;
 		if (!entity.getCardId() && this.props.cardOracle && this.props.cardOracle.has(+entity.getId())) {
-			let cardId = this.props.cardOracle.get(entity.getId());
+			let cardId = this.props.cardOracle.get(entity.getId()).cardId;
 			entity = new Entity(entity.getId(), entity.getTags(), cardId);
 			hidden = true;
 		}

--- a/ts/interfaces.d.ts
+++ b/ts/interfaces.d.ts
@@ -128,11 +128,16 @@ export interface CardDataProps {
 }
 
 export interface CardOracleProps {
-	cardOracle?: Immutable.Map<number, string>;
+	cardOracle?: Immutable.Map<number, RevealedCardData>;
 }
 
 export interface CardOracle extends EventEmitter {
-	getCardMap(): Immutable.Map<number, string>;
+	getCardMap(): Immutable.Map<number, RevealedCardData>;
+}
+
+export interface RevealedCardData {
+	cardId?: string;
+	creator?: number;
 }
 
 export interface AssetDirectoryProps {


### PR DESCRIPTION
This implements part of point 2 in #49. 

For cards in the player hand the text is displayed above the card, rather than below it. 
While just lifing the cards up more would be possible, with the current issues in Chrome (bottom of player cards cut off) this way is probably the better solution.

RevealedCardData could be extended to track more than `DISPLAYED_CREATOR` but I couldn't think of any other tags worth revealing.

Known issue: does not work if cardOracle is disabled (i.e. opponent cards are hidden).
