### PR TITLE
Implement combo highlighting

### DIFF
--- a/less/joust.less
+++ b/less/joust.less
@@ -146,11 +146,11 @@
 	filter: drop-shadow(0px 0px 7px rgb(0, 255, 0));
 
 	&.powered-up {
-		box-shadow: 0px 0px 10px rgb(255, 220, 0);
+		filter: drop-shadow(0px 0px 7px rgb(255, 210, 0));
 	}
 
 	&.combo {
-		box-shadow: 0px 0px 20px rgb(255, 255, 100);
+		filter: drop-shadow(0px 0px 7px rgb(255, 240, 0));
 	}
 }
 

--- a/ts/components/game/Card.tsx
+++ b/ts/components/game/Card.tsx
@@ -44,6 +44,9 @@ class Card extends React.Component<CardProps, {}> {
 		if (draggable) {
 			classNames.push('draggable');
 		}
+		if (entity.getTag(GameTag.COMBO)) {
+			classNames.push('combo');
+		}
 		if (entity.isPoweredUp()) {
 			classNames.push('powered-up');
 		}


### PR DESCRIPTION
-  'powered-up' and 'combo' now overwrite the drop-shadow filter instead of overlaying a box-shadow. 
- Updated colors: made 'powered-up' slightly more orange and 'combo' a stronger tint of yellow.

Closes #23.