### PR TITLE
Game result screen

### DIFF
--- a/less/joust.less
+++ b/less/joust.less
@@ -65,6 +65,12 @@
 	transition: background 0.8s;
 }
 
+.player.inactive {
+	.short, .tall {
+		filter: grayscale(75%) blur(3px);
+	}
+}
+
 .entity {
 	transition: box-shadow 0.15s, transform 0.15s;
 

--- a/less/joust.less
+++ b/less/joust.less
@@ -71,6 +71,12 @@
 	}
 }
 
+.player.inactive-colored {
+	.short, .tall {
+		filter: blur(3px);
+	}
+}
+
 .entity {
 	transition: box-shadow 0.15s, transform 0.15s;
 
@@ -148,7 +154,7 @@
 	}
 }
 
-.cost, .atk, .health, .durability, .armor {
+.cost, .atk, .health, .durability, .armor, .gameresult {
 	position: absolute;
 	display: block;
 	width: 20%;
@@ -163,6 +169,11 @@
 		1px -1px 0 #000,
 	-1px 1px 0 #000,
 	1px 1px 0 #000;
+}
+
+.gameresult {
+	font-size: 4em;
+	z-index: 100;
 }
 
 .atk, .health, .durability, .cost {

--- a/less/layout.less
+++ b/less/layout.less
@@ -33,6 +33,18 @@
 		height: 100%;
 	}
 
+	.gameresult {
+		position: absolute;
+		top: 35%;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		
+		.top& {
+			top: 45%;
+		}
+	}
+
 	.hand {
 		width: 75%;
 		overflow: hidden;

--- a/ts/components/game/Player.tsx
+++ b/ts/components/game/Player.tsx
@@ -15,7 +15,7 @@ import Weapon from "./Weapon";
 import Choices from "./Choices";
 import Rank from "./Rank";
 
-import {Zone, CardType, GameTag, ChoiceType, Mulligan} from "../../enums"
+import {Zone, CardType, GameTag, ChoiceType, Mulligan, PlayState} from "../../enums"
 import {OptionCallbackProps, CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps} from "../../interfaces";
 
 interface PlayerProps extends OptionCallbackProps, CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps, React.Props<any> {
@@ -186,9 +186,21 @@ class Player extends React.Component<PlayerProps, {}> {
 			classNames.push('current');
 		}
 
+		var gameresult = null;
+		switch (this.props.player.getTag(GameTag.PLAYSTATE)) {
+			case PlayState.WON:
+				gameresult = <div className="gameresult">Victory!</div>
+				classNames.push('inactive-colored');
+				break;
+			case PlayState.LOST:
+				classNames.push('inactive');
+				break;
+		}
+
 		if (this.props.isTop) {
 			return (
 				<div className={classNames.join(' ')}>
+					{gameresult}
 					{choices}
 					{tall}
 					{short}
@@ -198,6 +210,7 @@ class Player extends React.Component<PlayerProps, {}> {
 		else {
 			return (
 				<div className={classNames.join(' ')}>
+					{gameresult}
 					{choices}
 					{short}
 					{tall}

--- a/ts/components/game/Player.tsx
+++ b/ts/components/game/Player.tsx
@@ -15,7 +15,7 @@ import Weapon from "./Weapon";
 import Choices from "./Choices";
 import Rank from "./Rank";
 
-import {Zone, CardType, GameTag, ChoiceType} from "../../enums"
+import {Zone, CardType, GameTag, ChoiceType, Mulligan} from "../../enums"
 import {OptionCallbackProps, CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps} from "../../interfaces";
 
 interface PlayerProps extends OptionCallbackProps, CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps, React.Props<any> {
@@ -178,7 +178,11 @@ class Player extends React.Component<PlayerProps, {}> {
 			classNames.push('top');
 		}
 
-		if(this.props.isCurrent) {
+		if (this.props.choices) {
+			classNames.push('inactive');
+		}
+
+		if (this.props.isCurrent && this.props.player.getTag(GameTag.MULLIGAN_STATE) == Mulligan.DONE) {
 			classNames.push('current');
 		}
 


### PR DESCRIPTION
Based on choices-blur PR.

This adds somewhat of a game result screen at the end of the game. 
![victory](https://cloud.githubusercontent.com/assets/7737910/14409982/f58516d8-ff22-11e5-8c60-403d8346dd98.PNG)


- Both players blurred, defeated player desaturated.
- I couldn't find a good backdrop for the text. Game assets don't really fit in with the joust style here.
- Text is currently centered across the whole screen. Not sure if 75% (board) would be better.