### PR TITLE
Wait for TexturePreloader before displaying board

### DIFF
--- a/ts/components/GameWidget.tsx
+++ b/ts/components/GameWidget.tsx
@@ -125,6 +125,7 @@ class GameWidget extends React.Component<GameWidgetProps, GameWidgetState> {
 			assetDirectory={this.props.assetDirectory} textureDirectory={this.props.textureDirectory}
 			cards={this.state.cards} swapPlayers={this.state.swapPlayers}
 			cardOracle={this.state.isRevealingCards && this.state.cardOracle}
+			preloader={this.props.preloader}
 			/>);
 
 		if (this.props.scrubber) {

--- a/ts/components/GameWrapper.tsx
+++ b/ts/components/GameWrapper.tsx
@@ -8,9 +8,11 @@ import Option from "../Option";
 import PlayerEntity from "../Player";
 import {InteractiveBackend, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps} from "../interfaces";
 import {Zone} from "../enums";
+import TexturePreloader from "../TexturePreloader";
 
 interface GameWrapperProps extends CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps, React.Props<any> {
 	state: GameState;
+	preloader?: TexturePreloader;
 	interaction?: InteractiveBackend;
 	swapPlayers?: boolean;
 }
@@ -49,6 +51,14 @@ class GameWrapper extends React.Component<GameWrapperProps, {}> {
 		var players = allEntities.filter(GameWrapper.filterByCardType(CardType.PLAYER)) as Immutable.Iterable<number, PlayerEntity>;
 		if (players.count() == 0) {
 			return <p className="joust-message">Waiting for players&hellip; </p>;
+		}
+
+		if (this.props.preloader && !this.props.preloader.assetsReady()) {
+			return <p className="joust-message">Waiting for assets&hellip; </p>;
+		}
+
+		if (this.props.preloader && !this.props.preloader.texturesReady()) {
+			return <p className="joust-message">Waiting for textures&hellip; </p>;
 		}
 
 		// check if we need to swap the players

--- a/ts/interfaces.d.ts
+++ b/ts/interfaces.d.ts
@@ -9,6 +9,7 @@ import GameStateSink from "./state/GameStateSink";
 import GameStateScrubber from "./state/GameStateScrubber";
 import GameStateHistory from "./state/GameStateHistory";
 import Player from "./Player";
+import TexturePreloader from "./TexturePreloader";
 
 export interface DropTargetProps {
 	connectDropTarget?(jsx);
@@ -154,6 +155,7 @@ export interface GameWidgetProps extends AssetDirectoryProps, TextureDirectoryPr
 	getImageURL?: (cardId: string) => string;
 	exitGame?: () => void;
 	cardOracle: CardOracle;
+	preloader?: TexturePreloader;
 	width?: any;
 	height?: any;
 }

--- a/ts/run.tsx
+++ b/ts/run.tsx
@@ -98,6 +98,9 @@ class Viewer {
 		this.opts.sink = sink;
 		this.opts.scrubber = scrubber;
 		this.opts.cardOracle = decoder;
+		if (preloader.canPreload()) {
+			this.opts.preloader = preloader;
+		}
 
 		this.render();
 	}


### PR DESCRIPTION
This displays `Waiting for assets...` and `Waiting for textures...` before the game starts. 

The reason behind `heroPowerCount`: If the assets load faster than the replay file (usually the case), `working` will be 0 between assets and textures being loaded.

TODO:
- Delay playing the replay until textures and assets are loaded.
- Add a better loading screen :).
