### PR TITLE
Refactor resource tray, fix css

### DIFF
--- a/less/joust.less
+++ b/less/joust.less
@@ -219,57 +219,46 @@ div.visuals {
 	font-family: "Belwe Bd BT";
 	height: 1.4em;
 	padding: 0.1em;
-	background-color: rgba(0, 0, 0, 0.3);
 	align-self: center;
 
 	> span {
-		width: 3.3em;
+		width: 3em;
+		flex-shrink: 0;
 		color: white;
 		font-size: 0.8em;
-		height: 2.5em;
+		height: 100%;
 		text-align: center;
-		line-height: 2.5em;
 		align-self: center;
 		text-shadow: -1px -1px 0 #000,
 			1px -1px 0 #000,
 		-1px 1px 0 #000,
 		1px 1px 0 #000;
 	}
+	.crystals {
+		width: 100% - 3.2em;
+		margin-left: 0.2em;
+		.crystal {
+			height: 1.2em;
+			width: 10%;
+			max-width: 1.2em;
+			opacity: 1;
+			transition: filter 400ms linear, opacity 400ms linear;
 
-	.crystal {
-		position: relative;
-		height: 1.2em;
-		width: 1.2em;
-		opacity: 1;
-		-webkit-transition: -webkit-filter 400ms linear, opacity 400ms linear;
-		-moz-transition: -moz-filter 400ms linear, opacity 400ms linear;
-		-o-transition: -o-filter 400ms linear, opacity 400ms linear;
-		-ms-transition: opacity 400ms linear;
-		transition: filter 400ms linear, opacity 400ms linear;
+			&.full {
+				filter: brightness(100%);
+			}
 
-		&.full {
-			-webkit-filter: brightness(100%);
-			-moz-filter: brightness(100%);
-			-o-filter: brightness(100%);
-			filter: brightness(100%);
-		}
+			&.empty {
+				filter: brightness(50%);
+			}
 
-		&.empty {
-			-webkit-filter: brightness(50%);
-			-moz-filter: brightness(50%);
-			-o-filter: brightness(50%);
-			filter: brightness(50%);
-		}
+			&.hidden {
+				opacity: 0;
+			}
 
-		&.hidden {
-			opacity: 0;
-		}
-
-		&.locked {
-			-webkit-filter: grayscale(100%);
-			-moz-filter: grayscale(100%);
-			-o-filter: grayscale(100%);
-			filter: grayscale(100%);
+			&.locked {
+				filter: grayscale(100%);
+			}
 		}
 	}
 }

--- a/less/joust.less
+++ b/less/joust.less
@@ -242,7 +242,7 @@ div.visuals {
 			width: 10%;
 			max-width: 1.2em;
 			opacity: 1;
-			transition: filter 400ms linear, opacity 400ms linear;
+			transition: filter 400ms linear, opacity 400ms linear, width 400ms linear;
 
 			&.full {
 				filter: brightness(100%);

--- a/less/layout.less
+++ b/less/layout.less
@@ -45,7 +45,6 @@
 
 	.equipment {
 		width: 25%;
-		padding: 10px;
 		display: inline-flex;
 		flex-direction: column;
 		justify-content: space-between;
@@ -55,6 +54,7 @@
 			max-width: 100%;
 			height: 80%;
 			display: flex;
+			padding: 10px 10px 0px 10px;
 
 			> section {
 				height: 100%;
@@ -134,8 +134,12 @@
 }
 
 .tray {
+	border-top: 2px #b5b58d solid;
 	display: block;
-	width: 80%;
+	width: 100%;
+	> span {
+		border-right: 1px #b5b58d solid;
+	}
 }
 
 @secret-size: 20%;

--- a/ts/components/game/Player.tsx
+++ b/ts/components/game/Player.tsx
@@ -14,6 +14,7 @@ import Field from "./Field";
 import Weapon from "./Weapon";
 import Choices from "./Choices";
 import Rank from "./Rank";
+import ResourceTray from "./ResourceTray";
 
 import {Zone, CardType, GameTag, ChoiceType} from "../../enums"
 import {OptionCallbackProps, CardDataProps, CardOracleProps, AssetDirectoryProps, TextureDirectoryProps} from "../../interfaces";
@@ -125,33 +126,7 @@ class Player extends React.Component<PlayerProps, {}> {
 			textureDirectory={this.props.textureDirectory}
 			/>;
 
-		var crystals = [];
-		let resources = this.props.player.getTag(GameTag.RESOURCES) + this.props.player.getTag(GameTag.TEMP_RESOURCES);
-		let available = resources - this.props.player.getTag(GameTag.RESOURCES_USED);
-		for (let i = 0; i < this.props.player.getTag(GameTag.MAXRESOURCES); i++) {
-			var crystalClassNames = ['crystal'];
-			if (i < available) {
-				crystalClassNames.push('full');
-			}
-			else if (i < resources) {
-				if (i >= resources - this.props.player.getTag(GameTag.OVERLOAD_LOCKED)) {
-					crystalClassNames.push('locked');
-				}
-				else {
-					crystalClassNames.push('empty');
-				}
-			}
-			else {
-				crystalClassNames.push('hidden');
-			}
-			crystals.push(<img src={this.props.assetDirectory + 'images/mana_crystal.png'} key={i} className={crystalClassNames.join(' ') }></img>);
-		}
-		var tray = (
-			<div className="tray">
-				<span>{available}/{resources}</span>
-				{crystals}
-			</div>
-		);
+		var tray = <ResourceTray player={this.props.player} assetDirectory={this.props.assetDirectory} />;
 
 		let tall = <section className="tall">
 			{hand}

--- a/ts/components/game/ResourceTray.tsx
+++ b/ts/components/game/ResourceTray.tsx
@@ -14,6 +14,8 @@ class ResourceTray extends React.Component<ResourceTrayProps, {}> {
 		let resources = this.props.player.getTag(GameTag.RESOURCES) + this.props.player.getTag(GameTag.TEMP_RESOURCES);
 		let available = resources - this.props.player.getTag(GameTag.RESOURCES_USED);
 		let locked = this.props.player.getTag(GameTag.OVERLOAD_LOCKED);
+		var crystalStyle = {};
+		crystalStyle['width'] = 100 / resources +'%';
 		for (let i = 0; i < this.props.player.getTag(GameTag.MAXRESOURCES); i++) {
 			var crystalClassNames = ['crystal'];
 			if (i < available) {
@@ -30,7 +32,7 @@ class ResourceTray extends React.Component<ResourceTrayProps, {}> {
 			else {
 				crystalClassNames.push('hidden');
 			}
-			crystals.push(<img src={this.props.assetDirectory + 'images/mana_crystal.png'} key={i} className={crystalClassNames.join(' ') }/>);
+			crystals.push(<img src={this.props.assetDirectory + 'images/mana_crystal.png'} key={i} className={crystalClassNames.join(' ')} style={crystalStyle}/>);
 		}
 		return	<div className="tray">
 					<span>{available}/{resources}</span>

--- a/ts/components/game/ResourceTray.tsx
+++ b/ts/components/game/ResourceTray.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import {GameTag} from "../../enums";
+import PlayerEntity from "../../Player";
+import {AssetDirectoryProps} from "../../interfaces"
+
+interface ResourceTrayProps extends AssetDirectoryProps, React.Props<any> {
+	player: PlayerEntity;
+}
+
+class ResourceTray extends React.Component<ResourceTrayProps, {}> {
+
+	public render(): JSX.Element {
+		var crystals = [];
+		let resources = this.props.player.getTag(GameTag.RESOURCES) + this.props.player.getTag(GameTag.TEMP_RESOURCES);
+		let available = resources - this.props.player.getTag(GameTag.RESOURCES_USED);
+		let locked = this.props.player.getTag(GameTag.OVERLOAD_LOCKED);
+		for (let i = 0; i < this.props.player.getTag(GameTag.MAXRESOURCES); i++) {
+			var crystalClassNames = ['crystal'];
+			if (i < available) {
+				crystalClassNames.push('full');
+			}
+			else if (i < resources) {
+				if (i >= resources - locked) {
+					crystalClassNames.push('locked');
+				}
+				else {
+					crystalClassNames.push('empty');
+				}
+			}
+			else {
+				crystalClassNames.push('hidden');
+			}
+			crystals.push(<img src={this.props.assetDirectory + 'images/mana_crystal.png'} key={i} className={crystalClassNames.join(' ') }/>);
+		}
+		return	<div className="tray">
+					<span>{available}/{resources}</span>
+					<div className="crystals">
+						{crystals}
+					</div>
+				</div>;
+	}
+}
+
+export default ResourceTray;


### PR DESCRIPTION
* Crystals no longer overflow outside the equipment panel.
* Tray now blends in with the rest of the UI a bit better.
* Moved ResourceTray to a separate component.

![resource](https://cloud.githubusercontent.com/assets/7737910/14530667/445f56b2-025a-11e6-8ba5-54ef329ddb46.PNG)
