### PR TITLE
Full card render on minion hover

### DIFF
--- a/less/entities.less
+++ b/less/entities.less
@@ -129,7 +129,7 @@
 		height: 100%;
 	}
 
-	.stats {
+	> .stats {
 		font-size: 1.3em;
 
 		.atk {
@@ -142,6 +142,23 @@
 			left: 59.5%;
 			top: 61%;
 			font-size: 1em;
+		}
+	}
+
+	.mouse-over {
+		display: block;
+		position: absolute;
+		height: 130%;
+		z-index: 51;
+		top: -20%;
+		left: 100%;
+		visibility: collapse;
+	}
+
+	&:hover {
+		z-index: 51;
+		.mouse-over {
+			visibility: visible;
 		}
 	}
 }

--- a/less/layout.less
+++ b/less/layout.less
@@ -72,7 +72,6 @@
 
 	.field {
 		width: 90%;
-		overflow: hidden;
 
 		> * {
 			flex-shrink: 1;

--- a/ts/components/game/Card.tsx
+++ b/ts/components/game/Card.tsx
@@ -18,6 +18,7 @@ interface CardProps extends EntityProps, OptionProps, CardDataProps, React.Props
 	connectDragSource?(react: React.ReactElement<CardProps>);
 	dragging?: boolean;
 	isHidden?: boolean;
+	defaultStats?: boolean;
 }
 
 class Card extends React.Component<CardProps, {}> {
@@ -89,7 +90,7 @@ class Card extends React.Component<CardProps, {}> {
 				var attack = <Attack attack={!this.props.isHidden ? entity.getAtk() : defaultAttack}
 					default={defaultAttack}/>;
 				var health = <Health health={!this.props.isHidden ? entity.getHealth() : defaultHealth}
-					damage={entity.getDamage() }
+					damage={this.props.defaultStats ? 0 : entity.getDamage()}
 					default={defaultHealth}/>;
 				stats = <div className="stats">{attack}{health}</div>;
 				break;
@@ -97,7 +98,7 @@ class Card extends React.Component<CardProps, {}> {
 				var attack = <Attack attack={!this.props.isHidden ? entity.getAtk() : defaultAttack}
 					default={defaultAttack}/>;
 				var durability = <div
-					className="durability">{!this.props.isHidden ? entity.getDurability() : defaultDurability}</div>;
+					className="durability">{!this.props.isHidden && !this.props.defaultStats ? entity.getDurability() : defaultDurability}</div>;
 				stats = <div className="stats">{attack}{durability}</div>;
 				textStyle = { color: "white" };
 		}

--- a/ts/components/game/Card.tsx
+++ b/ts/components/game/Card.tsx
@@ -174,6 +174,24 @@ class Card extends React.Component<CardProps, {}> {
 		description = description.replace(/#(\d+)/g, modifier(0, healingDoubling));
 		return description;
 	}
+
+	public shouldComponentUpdate(nextProps: CardProps, nextState) {
+		return (
+			this.props.option !== nextProps.option ||
+			this.props.isHidden !== nextProps.isHidden ||
+			this.props.entity.getTag(GameTag.COMBO) !== nextProps.entity.getTag(GameTag.COMBO) ||
+			this.props.entity.getTag(GameTag.POWERED_UP) !== nextProps.entity.getTag(GameTag.POWERED_UP) ||
+			this.props.entity.getTag(GameTag.ATK) !== nextProps.entity.getTag(GameTag.ATK) ||
+			this.props.entity.getTag(GameTag.HEALTH) !== nextProps.entity.getTag(GameTag.HEALTH) ||
+			this.props.entity.getTag(GameTag.DAMAGE) !== nextProps.entity.getTag(GameTag.DAMAGE) ||
+			this.props.entity.getTag(GameTag.COST) !== nextProps.entity.getTag(GameTag.COST) ||
+			this.props.controller.getTag(GameTag.CURRENT_SPELLPOWER) !== nextProps.controller.getTag(GameTag.CURRENT_SPELLPOWER) ||
+			this.props.controller.getTag(GameTag.SPELLPOWER_DOUBLE) !== nextProps.controller.getTag(GameTag.SPELLPOWER_DOUBLE) ||
+			this.props.controller.getTag(GameTag.HEALING_DOUBLE) !== nextProps.controller.getTag(GameTag.HEALING_DOUBLE) ||
+			this.props.controller.getTag(GameTag.CURRENT_HEROPOWER_DAMAGE_BONUS) !== nextProps.controller.getTag(GameTag.CURRENT_HEROPOWER_DAMAGE_BONUS) ||
+			this.props.controller.getTag(GameTag.HERO_POWER_DOUBLE) !== nextProps.controller.getTag(GameTag.HERO_POWER_DOUBLE)
+		);
+	}
 }
 
 export default DragSource('card', {

--- a/ts/components/game/Minion.tsx
+++ b/ts/components/game/Minion.tsx
@@ -3,6 +3,7 @@ import EntityInPlay from "./EntityInPlay";
 import {EntityInPlayProps} from "../../interfaces";
 import {GameTag} from "../../enums";
 import InPlayCardArt from "./visuals/InPlayCardArt";
+import Card from "./Card";
 
 import Attack from "./stats/Attack";
 import Health from "./stats/Health";
@@ -37,6 +38,17 @@ class Minion extends EntityInPlay<EntityInPlayProps, {}> {
 			<div key="stats" className="stats">
 				<Attack attack={entity.getAtk() } default={data.attack}/>
 				<Health health={entity.getHealth() } damage={entity.getDamage() } default={data.health}/>
+			</div>,
+			<div className="mouse-over">
+				<Card entity={entity}
+					  option={undefined}
+					  assetDirectory={this.props.assetDirectory}
+					  cards={this.props.cards}
+					  isHidden={false}
+					  controller={this.props.controller}
+					  textureDirectory={this.props.textureDirectory}
+					  defaultStats={true}
+				/>
 			</div>
 		];
 	}


### PR DESCRIPTION
This extends the `Minion` component to contain a (by default collapsed) `Card` component, that's revealed when hovering over the minion.

![screenshot 2016-04-16 11 02 24](https://cloud.githubusercontent.com/assets/7737910/14580091/bcb36a18-03c2-11e6-83ff-537ba9137e32.png)

I managed to fix the z-index problem I posted about on discord.

There are three remaining issues I'm not sure how to fix:
- When the tool tip is displayed (i.e. the minion is expanded), hovering over the full card will continue to display it.
- If the minion is "active", the full card is as well (see above). 
- Since the `stats` div is actually located below the minion, hovering over a minion, then the minion below it, will continue to display the card for the first minion. See here:
![screenshot 2016-04-16 11 05 15](https://cloud.githubusercontent.com/assets/7737910/14580103/5574ae06-03c3-11e6-8a20-7659fac64376.png)


Other things that would be nice to have:
- Slight delay before card is displayed.
- Fading the card in when it's revealed.