### PR TITLE
Highlight HeroPower when it's being played

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Show Prince Malchezaar at game start (#142, @azeier)
 - Show C'Thun stats in opponent hand (#133, @azeier)
 - Show C'Thun as a minion during ritual (#137, @azeier)
+- Highlight Hero Power when it's played (#140, @azeier)
 
 ### Changed
 - Update dependencies

--- a/less/joust.less
+++ b/less/joust.less
@@ -106,6 +106,11 @@
 		filter: drop-shadow(0px -3px 7px rgb(255, 255, 255));
 	}
 
+	&.highlight {
+		transform: scale(1.1);
+		filter: drop-shadow(0px -3px 7px rgb(255, 255, 255));
+	}
+
 	&.triggered {
 		.icon-trigger {
 			transition: filter 0.15s;

--- a/ts/components/game/HeroPower.tsx
+++ b/ts/components/game/HeroPower.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-
 import {EntityInPlayProps} from "../../interfaces";
 import EntityInPlay from "./EntityInPlay";
 import Cost from "./stats/Cost";
@@ -7,13 +6,25 @@ import Card from "./Card"
 import HeroPowerArt from "./visuals/HeroPowerArt";
 import {GameTag} from "../../enums";
 
-export default class HeroPower extends EntityInPlay<EntityInPlayProps> {
+interface HeroPowerProps extends EntityInPlayProps {
+	activated?: boolean;
+}
+
+export default class HeroPower extends EntityInPlay<HeroPowerProps> {
 	constructor() {
 		super('heroPower');
 	}
 
 	protected playWithClick():boolean {
 		return true;
+	}
+
+	protected getClassNames(): string[] {
+		let classNames = super.getClassNames();
+		if (this.props.activated) {
+			classNames.push("highlight");
+		}
+		return classNames;
 	}
 
 	protected jsx() {


### PR DESCRIPTION
I moved the descriptor loop up to only have to iterate over it once. 

There might be a better solution for early loop exit, I'm not entirely sure. But this should prevent the Hero Power from blinking if the top descriptor changes. Relevant changes are L75 and L104.

Closes #140.