### PR TITLE
Fix Windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix a null pointer in EventLog
 - Fix jumping to start/end of turn in reconnected games (#172)
 - Fix minions with charge being shown as asleep
+- Fix Windows build
 
 ## [0.8.0] - 2016-10-10
 ### Added

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "test": "karma start --single-run --no-auto-watch karma.conf.js",
-    "postinstall": "concurrently 'typings install' 'gulp enums:download'"
+    "postinstall": "concurrently \"typings install\" \"gulp enums:download\""
   },
   "author": "Benedict Etzel <developer@beheh.de>",
   "license": "UNLICENSED",


### PR DESCRIPTION
Per usage of [concurrently](https://github.com/kimmobrunfeldt/concurrently), the command in package.json should be quoted with escaped double quote marks. This fixes build issue in Windows 10 with node.js 7