### PR TITLE
Fixes master build

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bowser": "^1.6.0",
     "cookie_js": "^1.2.2",
     "cssnano": "^3.10.0",
+    "electron": "^1.7.11",
     "filereader-stream": "^1.0.0",
     "git-describe": "^4.0.1",
     "gulp": "^3.9.1",
@@ -68,7 +69,6 @@
   },
   "devDependencies": {
     "concurrently": "^3.5.1",
-    "electron": "^1.7.11",
     "jasmine": "^2.5.3",
     "karma": "^1.5.0",
     "karma-jasmine": "^1.1.0",


### PR DESCRIPTION
As result of my previous PR, master build/deployment fails
This fixes:
```
internal/streams/legacy.js:59
      throw er; // Unhandled stream error in pipe.
      ^
Error: /Users/dzannotti/code/Joust/ts/debug.tsx
(4,27): error TS2307: Cannot find module 'electron'.
```
I'm not sure if it's a typescript requirement or what else
webpack config doesn't include `debug.tsx` but none the less tscompiler is compiling debug.tsx which is looking for a devDep. This fixes it but i am unsure if the effort should be in keeping electron as devDep and exclude `debug.tsx` from deployment compilation